### PR TITLE
Fix: add tanh for expected normalized input

### DIFF
--- a/models/our_models/GLOCALNet.py
+++ b/models/our_models/GLOCALNet.py
@@ -34,6 +34,7 @@ class GLOCALNet_model(nn.Module):
 
         self.input_decoder = input_decoder
         self.leakyRELU = nn.LeakyReLU(0.1)
+        self.tanh = nn.Tanh()
         self.corr = CorrelationVolume()
 
         # L2 feature normalisation
@@ -181,7 +182,7 @@ class GLOCALNet_model(nn.Module):
         est_map4 = self.decoder4(x1=corr4, x3=init_map)
 
         # conversion to flow and from there PWCNet
-        flow4 = unnormalise_and_convert_mapping_to_flow(est_map4) / self.div
+        flow4 = unnormalise_and_convert_mapping_to_flow(self.tanh(est_map4)) / self.div
         flow4[:, 0, :, :] /= ratio_x
         flow4[:, 1, :, :] /= ratio_y
         up_flow4 = self.deconv4(flow4)


### PR DESCRIPTION
## Summary
This pull request addresses the fact that `unnormalise_and_convert_mapping_to_flow()` function expects a normalized input map with pixel values : [-1,1]. But it was **NOT** normalized and are input directly after a conv layer.

## Changes Introduced
- A tanh activation function is applied before input to the `unnormalise_and_convert_mapping_to_flow()` function.

## Notes
- Since the  `unnormalise_and_convert_mapping_to_flow()` is also used by GLUNet, which has been already trained; changes are not introduced to mod.py although it would have been a more robust solution.